### PR TITLE
Stripped whitespace from the message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 vendor
 tools
 .VERSION.mk
+*.gem

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -31,15 +31,20 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
       # We don't have syslog headers, so we just need to remove CEF:
       data.sub! /^CEF:/, ''
     end #if @syslog
+
     # Default any CEF unknown fields to unknown
-    data.gsub! '||', ''
+    data.gsub! '||', '|unknown|'
 
     # Now, break out the rest of the headers
     event['cef_version'], event['cef_vendor'], event['cef_product'], event['cef_device_version'], event['cef_sigid'], event['cef_name'], event['cef_severity'], event['message'] =  data.scan /(?:[^\|\\]|\\.)+/
-    # Now, try to break out the Extension Dictionary
+
+    # Strip any leading or trailing spaces
     message=event['message']
-    if message.to_s.strip.length != 0
-      message = message.strip
+    message=message.to_s.strip
+    event['message']=message
+
+    # Now, try to break out the Extension Dictionary
+    if message.length != 0
       message = message.split(/ ([\w\.]+)=/)
 
       key, value = message.shift.split('=',2)

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -36,6 +36,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     # Now, try to break out the Extension Dictionary
     message=event['message']
     if message.to_s.strip.length != 0
+      message = message.strip
       message = message.split(/ ([\w\.]+)=/)
 
       key, value = message.shift.split('=',2)

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -31,6 +31,9 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
       # We don't have syslog headers, so we just need to remove CEF:
       data.sub! /^CEF:/, ''
     end #if @syslog
+    # Default any CEF unknown fields to unknown
+    data.gsub! '||', ''
+
     # Now, break out the rest of the headers
     event['cef_version'], event['cef_vendor'], event['cef_product'], event['cef_device_version'], event['cef_sigid'], event['cef_name'], event['cef_severity'], event['message'] =  data.scan /(?:[^\|\\]|\\.)+/
     # Now, try to break out the Extension Dictionary


### PR DESCRIPTION
We were getting spaces at the start of the message, which was subsequently causing a nil exception when building the Extension Dictionary.

A simple strip fixes this issue.