### PR TITLE
Delete version.rb

### DIFF
--- a/lib/logstash/version.rb
+++ b/lib/logstash/version.rb
@@ -1,6 +1,0 @@
-# encoding: utf-8
-# The version of logstash.
-LOGSTASH_VERSION = "1.4.1.dev"
-
-# Note to authors: this should not include dashes because 'gem' barfs if
-# you include a dash in the version string.


### PR DESCRIPTION
Having this in the plugin caused bin/logstash -V to report the incorrect version. The plugin should not be setting the logstash version, so removing this resolves that problem.