### PR TITLE
Keep pipe character in extension part

### DIFF
--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -62,8 +62,9 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     end
     event = LogStash::Event.new
 
-    # Split by the pipes
-    event['cef_version'], event['cef_vendor'], event['cef_product'], event['cef_device_version'], event['cef_sigid'], event['cef_name'], event['cef_severity'], message = data.split /(?<!\\)[\|]/
+    # Split by the pipes, pipes in the extension part are perfectly valid and do not need escaping
+    event['cef_version'], event['cef_vendor'], event['cef_product'], event['cef_device_version'], event['cef_sigid'], event['cef_name'], event['cef_severity'], *message = data.split /(?<!\\)[\|]/
+    message = message.join('|')
 
     # Try and parse out the syslog header if there is one
     if event['cef_version'].include? ' '

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -369,6 +369,14 @@ describe LogStash::Codecs::CEF do
       end 
     end
 
+    let (:pipes_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this|has an pipe'}
+    it "should be OK with not escaped pipes in the message" do
+      subject.decode(pipes_in_message) do |e|
+        ext = e['cef_ext']
+        insist { ext['moo'] } == 'this|has an pipe'
+      end
+    end
+
     let (:syslog) { "Syslogdate Sysloghost CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
     it "Should detect headers before CEF starts" do
       subject.decode(syslog) do |e|


### PR DESCRIPTION
According to the CEF specification pipes (|) in the extension do not
need escaping and are therefore perfectly valid.

Fixes #9
Replaces #10 

thanks @us3r for your initial work.