### PR TITLE
Bugfix decode gotchas

### DIFF
--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -63,8 +63,21 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     event = LogStash::Event.new
 
     # Split by the pipes, pipes in the extension part are perfectly valid and do not need escaping
-    event['cef_version'], event['cef_vendor'], event['cef_product'], event['cef_device_version'], event['cef_sigid'], event['cef_name'], event['cef_severity'], *message = data.split /(?<!\\)[\|]/
+    # The better solution for the splitting regex would be /(?<!\\(\\\\)*)[\|]/, but this
+    # gives an "SyntaxError: (RegexpError) invalid pattern in look-behind" for the variable length look behind.
+    # Therefore one edge case is not handled properly: \\| (this should split, but it does not, because the escaped \ is not recognized)
+    # TODO: To solve all unescaping cases, regex is not suitable. A little parse should be written.
+    event['cef_version'], event['cef_vendor'], event['cef_product'], event['cef_device_version'], event['cef_sigid'], event['cef_name'], event['cef_severity'], *message = data.split /(?<=[^\\]\\\\)[\|]|(?<!\\)[\|]/
     message = message.join('|')
+
+    # Unescape pipes and backslash in header fields
+    event['cef_version'] = event['cef_version'].gsub(/\\\|/, '|').gsub(/\\\\/, '\\')
+    event['cef_vendor'] = event['cef_vendor'].gsub(/\\\|/, '|').gsub(/\\\\/, '\\')
+    event['cef_product'] = event['cef_product'].gsub(/\\\|/, '|').gsub(/\\\\/, '\\')
+    event['cef_device_version'] = event['cef_device_version'].gsub(/\\\|/, '|').gsub(/\\\\/, '\\')
+    event['cef_sigid'] = event['cef_sigid'].gsub(/\\\|/, '|').gsub(/\\\\/, '\\')
+    event['cef_name'] = event['cef_name'].gsub(/\\\|/, '|').gsub(/\\\\/, '\\')
+    event['cef_severity'] = event['cef_severity'].gsub(/\\\|/, '|').gsub(/\\\\/, '\\') unless event['cef_severity'].nil?
 
     # Try and parse out the syslog header if there is one
     if event['cef_version'].include? ' '
@@ -72,8 +85,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     end
 
     # Get rid of the CEF bit in the version
-    version = event['cef_version'].sub /^CEF:/, ''
-    event['cef_version'] = version
+    event['cef_version'] = event['cef_version'].sub /^CEF:/, ''
 
     # Strip any whitespace from the message
     if not message.nil? and message.include? '='

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -62,8 +62,9 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     end
     event = LogStash::Event.new
 
-    # Split by the pipes
-    event['cef_version'], event['cef_vendor'], event['cef_product'], event['cef_device_version'], event['cef_sigid'], event['cef_name'], event['cef_severity'], message = data.split /(?<!\\)[\|]/
+    # Split by the pipes, pipes in the extension part are perfectly valid and do not need escaping
+    event['cef_version'], event['cef_vendor'], event['cef_product'], event['cef_device_version'], event['cef_sigid'], event['cef_name'], event['cef_severity'], *message = data.split /(?<!\\)[\|]/
+    message = message.join('|')
 
     # Try and parse out the syslog header if there is one
     if event['cef_version'].include? ' '

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -80,15 +80,15 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
       message = message.strip
 
       # If the last KVP has no value, add an empty string, this prevents hash errors below
-      if message.end_with?("=")
-        message=message + ' '
+      if message.end_with?('=')
+        message=message + ' ' unless message.end_with?('\=')
       end
 
       # Now parse the key value pairs into it
       extensions = {}
       message = message.split(/ ([\w\.]+)=/)
       key, value = message.shift.split('=', 2)
-      extensions[key] = value
+      extensions[key] = value.gsub(/\\=/, '=').gsub(/\\\\/, '\\')
 
       Hash[*message].each{ |k, v| extensions[k] = v }
 

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -379,6 +379,14 @@ describe LogStash::Codecs::CEF do
       end 
     end
 
+    let (:pipes_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this|has an pipe'}
+    it "should be OK with not escaped pipes in the message" do
+      subject.decode(pipes_in_message) do |e|
+        ext = e['cef_ext']
+        insist { ext['moo'] } == 'this|has an pipe'
+      end
+    end
+
     let (:syslog) { "Syslogdate Sysloghost CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
     it "Should detect headers before CEF starts" do
       subject.decode(syslog) do |e|

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -395,6 +395,14 @@ describe LogStash::Codecs::CEF do
       end
     end
 
+    let (:equal_in_header) {'CEF:0|security|threatmanager=equal|1.0|100|trojan successfully stopped|10|'}
+    it "should be OK with equal in the headers" do
+      subject.decode(equal_in_header) do |e|
+        validate(e)
+        insist { e["cef_product"] } == "threatmanager=equal"
+      end
+    end
+
     let (:syslog) { "Syslogdate Sysloghost CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
     it "Should detect headers before CEF starts" do
       subject.decode(syslog) do |e|

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -387,6 +387,14 @@ describe LogStash::Codecs::CEF do
       end
     end
 
+    let (:escaped_equal_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this \=has escaped \= equals\='}
+    it "should be OK with escaped equal in the message" do
+      subject.decode(escaped_equal_in_message) do |e|
+        ext = e['cef_ext']
+        insist { ext['moo'] } == 'this =has escaped = equals='
+      end
+    end
+
     let (:syslog) { "Syslogdate Sysloghost CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
     it "Should detect headers before CEF starts" do
       subject.decode(syslog) do |e|


### PR DESCRIPTION
Addresses the gotchas, mentioned in #1.

For a 100% correct decoding, unescaping and processing of CEF, a little parser should be written, because the edge cases may not be handled properly with regex alone. 

Fixes #1 