### PR TITLE
CEF extension enumeration and flattening out JSON messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.0
  - breaking: Updated plugin to use new Java Event APIs
+ - Implements the dictionary translation for abbreviated CEF field names from chapter Chapter 2: ArcSight Extension Dictionary page 3 of 39 [CEF specification](https://protect724.hp.com/docs/DOC-1072). 
 
 ## 2.1.3
  - Switch in-place sub! to sub when extracting `cef_version`. new Logstash Java Event does not support in-place String changes.
@@ -15,7 +16,6 @@
  - Config option `sev` is deprecated, use `severity` instead.
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ Contributors:
 * Jordan Sissel (jordansissel)
 * João Duarte (jsvd)
 * Nick Ethier (nickethier)
+* Nicholas Lim (nich07as)
 * Pete Fritchman (fetep)
 * Pier-Hugues Pellerin (ph)
 * Karl Stoney (Stono)

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -49,8 +49,8 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   # Fields to be included in CEV extension part as key/value pairs
   config :fields, :validate => :array, :default => []
 
-  HEADER_FIELDS = ['cef_version','cef_vendor','cef_product','cef_device_version','cef_sigid','cef_name','cef_severity']
-  
+  HEADER_FIELDS = ['cefVersion','deviceVendor','deviceProduct','deviceVersion','deviceEventClassId','name','severity']
+
   public
   def initialize(params={})
     super(params)
@@ -85,14 +85,14 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     message = split_data[HEADER_FIELDS.size..-1].join('|')
 
     # Try and parse out the syslog header if there is one
-    if event.get('cef_version').include? ' '
-      split_cef_version= event.get('cef_version').rpartition(' ')
+    if event.get('cefVersion').include? ' '
+      split_cef_version= event.get('cefVersion').rpartition(' ')
       event.set('syslog', split_cef_version[0])
-      event.set('cef_version',split_cef_version[2])
+      event.set('cefVersion',split_cef_version[2])
     end
 
     # Get rid of the CEF bit in the version
-    event.set('cef_version', event.get('cef_version').sub(/^CEF:/, ''))
+    event.set('cefVersion', event.get('cefVersion').sub(/^CEF:/, ''))
 
     # Strip any whitespace from the message
     if not message.nil? and message.include? '='
@@ -103,14 +103,31 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
         message=message + ' ' unless message.end_with?('\=')
       end
 
-      # Now parse the key value pairs into it
-      extensions = {}
-      message = message.split(/ ([\w\.]+)=/)
-      key, value = message.shift.split('=', 2)
-      extensions[key] = value.gsub(/\\=/, '=').gsub(/\\\\/, '\\')
-      Hash[*message].each{ |k, v| extensions[k] = v }
-      # And save the new has as the extensions
-      event.set('cef_ext', extensions)
+      # Introducing custom delimiters instead of space to avoid convolution when parsing fields with ' ' spaces.
+      # Example : cs1Label=New Malware cs1=Conficker ==> cs1Label=New Malware|^^^cs1=Conficker
+      message=message.gsub((/\s+(\w+=)/)||(/(\w+=)/),'|^^^\1')
+
+      # Truncating the additional fields, if needed it can be mapped from ArcSight's connector; otherwise also protects the dot (.) notations in implmentations for Elasticsearch v 2.4 and below
+      # Example ad.field[0]=XXXX ad.name[2]=abc
+      message=message.gsub((/ (ad.\w+.*\]\=[^|^^^]+)/),'')
+
+      # Splits the fields by the custom delimiter introduced above
+      message=message.split('|^^^')
+
+      # Introducing a custom delimiter to avoid convolution when parsing fields with '=' equals
+      # Example : cs4=https://<sampledomain>/event_stream/events_for_bot?inc_id\\=50; requestUrl=http://db:3301/q='select * from a where b=c'
+      for i in 0..message.length-1
+        message[i]=message[i].sub(/\=/, "***")
+      end
+
+      # Translating and flattening the CEF extensions with known field names as documented in the Common Event Format whitepaper
+      mappings = { "act" => "deviceAction", "app" => "applicationProtocol", "c6a1" => "deviceCustomIPv6Address1", "c6a1Label" => "deviceCustomIPv6Address1Label", "c6a2" => "deviceCustomIPv6Address2", "c6a2Label" => "deviceCustomIPv6Address2Label", "c6a3" => "deviceCustomIPv6Address3", "c6a3Label" => "deviceCustomIPv6Address3Label", "c6a4" => "deviceCustomIPv6Address4", "c6a4Label" => "deviceCustomIPv6Address4Label", "cat" => "deviceEventCategory", "cfp1" => "deviceCustomFloatingPoint1", "cfp1Label" => "deviceCustomFloatingPoint1Label", "cfp2" => "deviceCustomFloatingPoint2", "cfp2Label" => "deviceCustomFloatingPoint2", "cfp3" => "deviceCustomFloatingPoint3", "cfp3Label" => "deviceCustomFloatingPoint4Label", "cfp4" => "deviceCustomFloatingPoint4", "cfp4Label" => "deviceCustomFloatingPoint4Label", "cn1" => "deviceCustomNumber1", "cn1Label" => "deviceCustomNumber1Label", "cn2" => "deviceCustomNumber2", "cn2Label" => "deviceCustomNumber2Label", "cn3" => "deviceCustomNumber3", "cn3Label" => "deviceCustomNumber3Label", "cnt" => "baseEventCount", "cs1" => "deviceCustomString1", "cs1Label" => "deviceCustomString1Label", "cs2" => "deviceCustomString2", "cs2Label" => "deviceCustomString2Label", "cs3" => "deviceCustomString3", "cs3Label" => "deviceCustomString3Label", "cs4" => "deviceCustomString4", "cs4Label" => "deviceCustomString4Label", "cs5" => "deviceCustomString5", "cs5Label" => "deviceCustomString5Label", "cs6" => "deviceCustomString6", "cs6Label" => "deviceCustomString6Label", "dhost" => "destinationHostName", "dmac" => "destinationMacAddress", "dntdom" => "destinationNTDomain", "dpid" => "destinationProcessId", "dpriv" => "destinationUserPrivileges", "dproc" => "destinationProcessName", "dpt" => "destinationPort", "dst" => "destinationAddress", "duid" => "destinationUserId", "duser" => "destinationUserName", "dvc" => "deviceAddress", "dvchost" => "deviceHostName", "dvcpid" => "deviceProcessId", "end" => "endTime", "fname" => "fileName", "fsize" => "fileSize", "in" => "bytesIn", "msg" => "message", "out" => "bytesOut", "proto" => "transportProtocol", "request" => "requestUrl", "rt" => "receiptTime", "shost" => "sourceHostName", "smac" => "sourceMacAddress", "sntdom" => "sourceNtDomain", "spid" => "sourceProcessId", "spriv" => "sourceUserPrivileges", "sproc" => "sourceProcessName", "spt" => "sourcePort", "src" => "sourceAddress", "start" => "startTime", "suid" => "sourceUserId", "suser" => "sourceUserName", "ahost" => "agentHost", "art" => "agentReceiptTime", "at" => "agentType", "aid" => "agentId", "_cefVer" => "cefVersion", "agt" => "agentAddress", "av" => "agentVersion", "atz" => "agentTimeZone", "dtz" => "destinationTimeZone", "slong" => "sourceLongitude", "slat" => "sourceLatitude", "dlong" => "destinationLongitude", "dlat" => "destinationLatitude", "catdt" => "categoryDeviceType", "mrt" => "managerReceiptTime" }
+
+      message=message.map {|s| k, v = s.split('***'); "#{mappings[k] || k }=#{v}"}
+      message=message.each_with_object({}) do |k|
+        key, value = k.split(/\s*=\s*/,2)
+        event.set(key, value)
+      end
     end
 
     yield event

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/cef"
 require "logstash/event"
@@ -317,6 +318,144 @@ describe LogStash::Codecs::CEF do
   end
 
   context "#decode" do
+    let (:codec_v1) { LogStash::Codecs::CEF.new(:deprecated_v1_fields => true) }
+    let (:message) { "CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
+
+    def validate(e)
+      insist { e.is_a?(LogStash::Event) }
+      insist { e.get('cef_version') } == "0"
+      insist { e.get('cef_device_version') } == "1.0"
+      insist { e.get('cef_sigid') } == "100"
+      insist { e.get('cef_name') } == "trojan successfully stopped"
+      insist { e.get('cef_severity') } == "10"
+    end
+
+    it "deprecated - should parse the cef headers" do
+      subject.decode(message) do |e|
+        validate(e)
+        ext = e.get('cef_ext')
+        insist { e.get("cef_vendor") } == "security"
+        insist { e.get("cef_product") } == "threatmanager"
+      end
+    end
+
+    it "deprecated - should parse the cef body" do
+      subject.decode(message) do |e|
+        ext = e.get('cef_ext')
+        insist { ext['src'] } == "10.0.0.192"
+        insist { ext['dst'] } == "12.121.122.82"
+        insist { ext['spt'] } == "1232"
+      end
+    end
+
+    let (:no_ext) { "CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|" }
+    it "deprecated - should be OK with no extension dictionary" do
+      subject.decode(no_ext) do |e|
+        validate(e)
+        insist { e.get("cef_ext") } == nil
+      end
+    end
+
+    let (:missing_headers) { "CEF:0|||1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
+    it "deprecated - should be OK with missing CEF headers (multiple pipes in sequence)" do
+      subject.decode(missing_headers) do |e|
+        validate(e)
+        insist { e.get("cef_vendor") } == ""
+        insist { e.get("cef_product") } == ""
+      end
+    end
+
+    let (:leading_whitespace) { "CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10| src=10.0.0.192 dst=12.121.122.82 spt=1232" }
+    it "deprecated - should strip leading whitespace from the message" do
+      subject.decode(leading_whitespace) do |e|
+        validate(e)
+      end
+    end
+
+    let (:escaped_pipes) { 'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this\|has an escaped pipe' }
+    it "deprecated - should be OK with escaped pipes in the message" do
+      subject.decode(escaped_pipes) do |e|
+        ext = e.get('cef_ext')
+        insist { ext['moo'] } == 'this\|has an escaped pipe'
+      end
+    end
+
+    let (:pipes_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this|has an pipe'}
+    it "deprecated - should be OK with not escaped pipes in the message" do
+      subject.decode(pipes_in_message) do |e|
+        ext = e.get('cef_ext')
+        insist { ext['moo'] } == 'this|has an pipe'
+      end
+    end
+
+    let (:escaped_equal_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this \=has escaped \= equals\='}
+    it "deprecated - should be OK with escaped equal in the message" do
+      subject.decode(escaped_equal_in_message) do |e|
+        ext = e.get('cef_ext')
+        insist { ext['moo'] } == 'this =has escaped = equals='
+      end
+    end
+
+    let (:escaped_backslash_in_header) {'CEF:0|secu\\\\rity|threat\\\\manager|1.\\\\0|10\\\\0|tro\\\\jan successfully stopped|\\\\10|'}
+    it "deprecated - should be OK with escaped backslash in the headers" do
+      subject.decode(escaped_backslash_in_header) do |e|
+        insist { e.get("cef_version") } == '0'
+        insist { e.get("cef_vendor") } == 'secu\\rity'
+        insist { e.get("cef_product") } == 'threat\\manager'
+        insist { e.get("cef_device_version") } == '1.\\0'
+        insist { e.get("cef_sigid") } == '10\\0'
+        insist { e.get("cef_name") } == 'tro\\jan successfully stopped'
+        insist { e.get("cef_severity") } == '\\10'
+      end
+    end
+
+    let (:escaped_backslash_in_header_edge_case) {'CEF:0|security\\\\\\||threatmanager\\\\|1.0|100|trojan successfully stopped|10|'}
+    it "deprecated - should be OK with escaped backslash in the headers (edge case: escaped slash in front of pipe)" do
+      subject.decode(escaped_backslash_in_header_edge_case) do |e|
+        validate(e)
+        insist { e.get("cef_vendor") } == 'security\\|'
+        insist { e.get("cef_product") } == 'threatmanager\\'
+      end
+    end
+
+    let (:escaped_pipes_in_header) {'CEF:0|secu\\|rity|threatmanager\\||1.\\|0|10\\|0|tro\\|jan successfully stopped|\\|10|'}
+    it "deprecated - should be OK with escaped pipes in the headers" do
+      subject.decode(escaped_pipes_in_header) do |e|
+        insist { e.get("cef_version") } == '0'
+        insist { e.get("cef_vendor") } == 'secu|rity'
+        insist { e.get("cef_product") } == 'threatmanager|'
+        insist { e.get("cef_device_version") } == '1.|0'
+        insist { e.get("cef_sigid") } == '10|0'
+        insist { e.get("cef_name") } == 'tro|jan successfully stopped'
+        insist { e.get("cef_severity") } == '|10'
+      end
+    end
+
+    let (:escaped_backslash_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this \\\\has escaped \\\\ backslashs\\\\'}
+    it "deprecated - should be OK with escaped backslashs in the message" do
+      subject.decode(escaped_backslash_in_message) do |e|
+        ext = e.get('cef_ext')
+        insist { ext['moo'] } == 'this \\has escaped \\ backslashs\\'
+      end
+    end
+
+    let (:equal_in_header) {'CEF:0|security|threatmanager=equal|1.0|100|trojan successfully stopped|10|'}
+    it "deprecated - should be OK with equal in the headers" do
+      subject.decode(equal_in_header) do |e|
+        validate(e)
+        insist { e.get("cef_product") } == "threatmanager=equal"
+      end
+    end
+
+    let (:syslog) { "Syslogdate Sysloghost CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
+    it "deprecated - Should detect headers before CEF starts" do
+      subject.decode(syslog) do |e|
+        validate(e)
+        insist { e.get('syslog') } == 'Syslogdate Sysloghost'
+      end
+    end
+
+    let (:deprecated_v1_fields) { LogStash::Codecs::CEF.new(:deprecated_v1_fields => false) }
     let (:message) { "CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
 
     def validate(e)
@@ -338,7 +477,7 @@ describe LogStash::Codecs::CEF do
 
     it "should parse the cef body" do
       subject.decode(message) do |e|
-        insist { e.get("sourceAddress")} == "10.0.0.192"
+        insist { e.get("sourceAddress") } == "10.0.0.192"
         insist { e.get("destinationAddress") } == "12.121.122.82"
         insist { e.get("sourcePort") } == "1232"
       end
@@ -360,6 +499,16 @@ describe LogStash::Codecs::CEF do
       end
     end
 
+    let (:preserve_unmatched_key_mappings) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 moo=new_values here'}
+    it "should remove preserve unmatched key mappings" do
+      subject.decode(preserve_unmatched_key_mappings) do |e|
+        validate(e)
+        insist { e.get("sourceAddress") } == "10.0.0.192"
+        insist { e.get("destinationAddress") } == "12.121.122.82"
+        insist { e.get("moo") } == "new_values here"
+      end
+    end
+
     let (:escaped_pipes) { 'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this\|has an escaped pipe' }
     it "should be OK with escaped pipes in the message" do
       subject.decode(escaped_pipes) do |e|
@@ -374,10 +523,10 @@ describe LogStash::Codecs::CEF do
       end
     end
 
-    let (:equal_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this =has = equals\='}
-    it "should be OK with equal in the message" do
-      subject.decode(equal_in_message) do |e|
-        insist { e.get("moo") } == 'this =has = equals\='
+    let (:escaped_equal_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this \=has escaped \= equals\='}
+    it "should be OK with escaped equal in the message" do
+      subject.decode(escaped_equal_in_message) do |e|
+        insist { e.get("moo") } == 'this =has escaped = equals='
       end
     end
 
@@ -416,10 +565,10 @@ describe LogStash::Codecs::CEF do
       end
     end
 
-    let (:backslash_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this \\has \\ backslashs\\'}
-    it "should be OK with backslashs in the message" do
-      subject.decode(backslash_in_message) do |e|
-        insist { e.get("moo") } == 'this \\has \\ backslashs\\'
+    let (:escaped_backslash_in_message) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|moo=this \\\\has escaped \\\\ backslashs\\\\'}
+    it "should be OK with escaped backslashs in the message" do
+      subject.decode(escaped_backslash_in_message) do |e|
+        insist { e.get("moo") } == 'this \\has escaped \\ backslashs\\'
       end
     end
 
@@ -428,6 +577,14 @@ describe LogStash::Codecs::CEF do
       subject.decode(equal_in_header) do |e|
         validate(e)
         insist { e.get("deviceProduct") } == "threatmanager=equal"
+      end
+    end
+
+    let (:syslog) { "Syslogdate Sysloghost CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
+    it "Should detect headers before CEF starts" do
+      subject.decode(syslog) do |e|
+        validate(e)
+        insist { e.get('syslog') } == 'Syslogdate Sysloghost'
       end
     end
 
@@ -463,16 +620,6 @@ describe LogStash::Codecs::CEF do
       end
     end
 
-    let (:preserve_unmatched_key_mappings) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 new_key_by_device=new_values here'}
-    it "should remove ad.fields" do
-      subject.decode(preserve_unmatched_key_mappings) do |e|
-        validate(e)
-        insist { e.get("sourceAddress") } == "10.0.0.192"
-        insist { e.get("destinationAddress") } == "12.121.122.82"
-        insist { e.get("new_key_by_device") } == "new_values here"
-      end
-    end
-
     let (:translate_abbreviated_cef_fields) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 proto=TCP shost=source.host.name dhost=destination.host.name spt=11024 dpt=9200'}
     it "should translate most known abbreviated CEF field names" do
       subject.decode(translate_abbreviated_cef_fields) do |e|
@@ -486,21 +633,39 @@ describe LogStash::Codecs::CEF do
         insist { e.get("destinationPort") } == "9200"
       end
     end
-
-    let (:syslog) { "Syslogdate Sysloghost CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82 spt=1232" }
-    it "Should detect headers before CEF starts" do
-      subject.decode(syslog) do |e|
-        validate(e)
-        insist { e.get('syslog') } == 'Syslogdate Sysloghost'
-      end
-    end
   end
 
   context "encode and decode" do
     subject(:codec) { LogStash::Codecs::CEF.new }
 
     let(:results)   { [] }
+    let (:deprecated_v1_fields) { LogStash::Codecs::CEF.new(:deprecated_v1_fields => true) }
 
+    it "deprecated - should return an equal event if encoded and decoded again" do
+      codec.on_event{|data, newdata| results << newdata}
+      codec.vendor = "%{cef_vendor}"
+      codec.product = "%{cef_product}"
+      codec.version = "%{cef_device_version}"
+      codec.signature = "%{cef_sigid}"
+      codec.name = "%{cef_name}"
+      codec.severity = "%{cef_severity}"
+      codec.fields = [ "foo" ]
+      event = LogStash::Event.new("cef_vendor" => "vendor", "cef_product" => "product", "cef_device_version" => "2.0", "cef_sigid" => "signature", "cef_name" => "name", "cef_severity" => "1", "foo" => "bar")
+      codec.encode(event)
+      codec.decode(results.first) do |e|
+        expect(e.get('cef_vendor')).to be == event.get('cef_vendor')
+        expect(e.get('cef_product')).to be == event.get('cef_product')
+        expect(e.get('cef_device_version')).to be == event.get('cef_device_version')
+        expect(e.get('cef_sigid')).to be == event.get('cef_sigid')
+        expect(e.get('cef_name')).to be == event.get('cef_name')
+        expect(e.get('cef_severity')).to be == event.get('cef_severity')
+        # decode saves extensions as hash to 'cef_ext'
+        expect(e.get('[cef_ext][foo]')).to be == event.get('foo')
+      end
+    end
+
+    let(:results)   { [] }
+    let (:deprecated_v1_fields) { LogStash::Codecs::CEF.new(:deprecated_v1_fields => false) }
     it "should return an equal event if encoded and decoded again" do
       codec.on_event{|data, newdata| results << newdata}
       codec.vendor = "%{deviceVendor}"


### PR DESCRIPTION
This PR is mainly enhancing the decode portion of the codec to achieve the following:

- Adhere to the Common Event Format naming conventions highlighted in the CEF whitepaper;

- Enumerate the abbreviated CEF field names to properly structured names (i.e. src=sourceAddress, dst=destinationAddress, spt=sourcePort etc)

- Flatten out the document structure instead of cef_ext.src as a field name, it should just read sourceAddress