### PR TITLE
Add delimiter setting so this codec can work for TCP input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+ - Add `delimiter` setting. This allows the decoder to be used with inputs like the TCP input where event delimiters are used.
+
 ## 4.0.0
  - Implements the dictionary translation for abbreviated CEF field names from chapter Chapter 2: ArcSight Extension Dictionary    page 3 of 39 [CEF specification](https://protect724.hp.com/docs/DOC-1072).
  - add `_cefparsefailure` tag on failed decode

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -65,7 +65,8 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   #
   #     input {
   #       tcp {
-  #         codec => cef { delimiter => "\r\n"
+  #         codec => cef { delimiter => "\r\n" }
+  #         # ... 
   #       }
   #     }
   #

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -40,7 +40,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   # Defined as field of type string to allow sprintf. The value will be validated
   # to be an integer in the range from 0 to 10 (including).
   # All invalid values will be mapped to the default of 6.
-  config :sev, :validate => :string, :default => "6", :deprecated => "This setting is being deprecated, use :severity instead."
+  config :sev, :validate => :string, :deprecated => "This setting is being deprecated, use :severity instead."
 
   # Severity field in CEF header. The new value can include `%{foo}` strings
   # to help you build a new value from other parts of the event.
@@ -56,7 +56,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   # Set this flag if you want to have both v1 and v2 fields indexed at the same time. Note that this option will increase 
   # the index size and data stored in outputs like Elasticsearch
   # This option is available to ease transition to new schema
-  config :deprecated_v1_fields, :validate => :boolean, :default => false, :deprecated => "This setting is being deprecated"
+  config :deprecated_v1_fields, :validate => :boolean, :deprecated => "This setting is being deprecated"
 
   # If your input puts a delimiter between each CEF event, you'll want to set
   # this to be that delimiter.
@@ -208,7 +208,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
 
     # :sev is deprecated and therefore only considered if :severity equals the default setting or is invalid
     severity = sanitize_severity(event, @severity)
-    if severity == self.class.get_config["severity"][:default]
+    if severity == self.class.get_config["severity"][:default] && @sev
       # Use deprecated setting sev
       severity = sanitize_severity(event, @sev)
     end

--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cef'
-  s.version         = '4.0.0'
+  s.version         = '4.1.0'
   s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "CEF codec to parse and encode CEF formated logs"

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -358,11 +358,15 @@ describe LogStash::Codecs::CEF do
           raise Exception.new("Should not get here. If we do, it means the decoder emitted an event before the delimiter was seen?")
         end
 
+        event = false;
         subject.decode("\r\n") do |e|
           validate(e)
           insist { e.get("deviceVendor") } == "security"
           insist { e.get("deviceProduct") } == "threatmanager"
+          event = true
         end
+
+        expect(event).to be_truthy
       end
     end
 


### PR DESCRIPTION
Adds a new `delimiter` setting so that this plugin can work with the TCP input (or any other stream-of-bytes input)