### PR TITLE
Implement `raw_data_field` option

### DIFF
--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -555,6 +555,18 @@ describe LogStash::Codecs::CEF do
         insist { e.get('syslog') } == 'Syslogdate Sysloghost'
       end
     end
+
+    context "with raw_data_field set" do
+      subject(:codec) { LogStash::Codecs::CEF.new("raw_data_field" => "message_raw") }
+
+      it "should return the raw message in field message_raw" do
+        subject.decode(message) do |e|
+          validate(e)
+          insist { e.get("message_raw") } == message
+        end
+      end
+    end
+
   end
 
   context "decode with deprecated version option" do


### PR DESCRIPTION
The `raw_data_field` option allows to keep the original, unparsed
raw data and to store it to the field with the provided name.

Closes #34
Related to: https://github.com/elastic/logstash/issues/6932