### PR TITLE
correctly parse events with raw.event preserved

### DIFF
--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -158,7 +158,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
       # Appropriately tokenizing the additional fields when ArcSight connectors are sending events using "COMPLETE" mode processing.
       # If these fields are NOT needed, then set the ArcSight processing mode for this destination to "FASTER" or "FASTEST"
       # Refer to ArcSight's SmartConnector user configuration guide
-      message = message.gsub((/(\s+(\w+\.[^\s]\w+[^\|\s\.\=]+\=))/),'|^^^\2')
+      message = message.gsub((/(\s+(\w+\.[^\s]\w+[^\|\s\.\=]+(?<!\\)\=))/),'|^^^\2')
       message = message.split('|^^^')
 
       # Replaces the '=' with '***' to avoid conflict with strings with HTML content namely key-value pairs where the values contain HTML strings
@@ -171,6 +171,8 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
       message = message.map {|s| k, v = s.split('***'); "#{MAPPINGS[k] || k }=#{v}"}
       message = message.each_with_object({}) do |k|
         key, value = k.split(/\s*=\s*/,2)
+        key = key.gsub("[", "_")
+        key = key.gsub("]", "_")
         event.set(key, value)
       end
     end

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -171,8 +171,6 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
       message = message.map {|s| k, v = s.split('***'); "#{MAPPINGS[k] || k }=#{v}"}
       message = message.each_with_object({}) do |k|
         key, value = k.split(/\s*=\s*/,2)
-        key = key.gsub("[", "_")
-        key = key.gsub("]", "_")
         event.set(key, value)
       end
     end


### PR DESCRIPTION
changed `\=` to `(?<!\\)\=`
the literal equals sign is not ideal and leads to numerous paring errors.  Instead, we need to make sure it is not preceded by a backslash to capture raw events contained within valid CEF.  Example:

`ad.rawEvent=CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|key\=value key1\=value1`

