### PR TITLE
encoding: coerce input data to UTF-8 to comply with spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.3
+ - Fix handling of higher-plane UTF-8 characters in message body
+
 ## 5.0.2
   - Update gemspec summary
 

--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cef'
-  s.version         = '5.0.2'
+  s.version         = '5.0.3'
   s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the ArcSight Common Event Format (CEF)."


### PR DESCRIPTION
The [Common Event Format][] dicates that inputs MUST be `UTF-8`, but in Logstash
strings are typically passed to the Codec flagged as `BINARY` (regardless of
their contents).

Before processing the CEF input, use `LogStash::Util::Charset` to load the
input bytes as the CEF-specified UTF-8, ensuring that multi-byte character
operations are supported on the resulting strings downstream.

If doing so produces an invalid UTF-8 byte sequence, bail early to avoid
wasted work; this will cause the input bytes to be emitted verbatim as the
event's `message`.

[Common Event Format]: https://web.archive.org/web/20160422182529/https://kc.mcafee.com/resources/sites/MCAFEE/content/live/CORP_KNOWLEDGEBASE/78000/KB78712/en_US/CEF_White_Paper_20100722.pdf