### PR TITLE
Add missing "dvcmac" => "deviceMacAddress" field.

### DIFF
--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -125,6 +125,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
       "duser" => "destinationUserName",
       "dvc" => "deviceAddress",
       "dvchost" => "deviceHostName",
+      "dvcmac" => "deviceMacAddress",
       "dvcpid" => "deviceProcessId",
       "end" => "endTime",
       "fname" => "fileName",


### PR DESCRIPTION
I propose the addition of the following missing field that is present in the CEF specifications document:
dvcmac => deviceMacAddress

Since this will inevitably change the behavior of the codec that ignored this field until now, I have followed Collin's suggestion and put this in its own pull request.
