### PR TITLE
[Doc] Corrections to cef-codec doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## 5.0.7
+  - Fixed minor doc inconsistencies (added reverse_mapping to options table, moved it to alpha order in option descriptions, fixed typo)
+  [#60](https://github.com/logstash-plugins/logstash-codec-cef/pull/60)
+
 ## 5.0.6
   - Added reverse_mapping option, which can be used to make encoder compliant to spec [#51](https://github.com/logstash-plugins/logstash-codec-cef/pull/51)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -37,6 +37,7 @@ produce an event with the payload as the 'message' field and a '_cefparsefailure
 | <<plugins-{type}s-{plugin}-fields>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-product>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-reverse_mapping>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-severity>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-signature>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-vendor>> |<<string,string>>|No
@@ -75,14 +76,6 @@ This setting allows the following character sequences to have special meaning:
   * Value type is <<boolean,boolean>>
   * There is no default value for this setting.
 
-[id="plugins-{type}s-{plugin}-reverse_mapping"]
-===== `reverse_mapping`
-
-  * Value type is <<<boolean,boolean>>
-  * Default value is `false`
-
-Set to true to adhere to the specifications and encode using the CEF key name (short name) for the CEF field names.
-
 [id="plugins-{type}s-{plugin}-fields"]
 ===== `fields` 
 
@@ -108,6 +101,16 @@ to help you build a new value from other parts of the event.
 
 Device product field in CEF header. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
+
+
+[id="plugins-{type}s-{plugin}-reverse_mapping"]
+===== `reverse_mapping`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Set to true to adhere to the specifications and encode using the CEF key name (short name) for the CEF field names.
+
 
 [id="plugins-{type}s-{plugin}-sev"]
 ===== `sev`  (OBSOLETE)

--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cef'
-  s.version         = '5.0.6'
+  s.version         = '5.0.7'
   s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the ArcSight Common Event Format (CEF)."


### PR DESCRIPTION
Fixed minor doc inconsistencies in cef-codec doc
- added reverse_mapping to options table
- moved `reverse_mapping` to alpha order in option descriptions
- fixed typo in type
