### PR TITLE
support keys with only two characters after the dot

### DIFF
--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -195,7 +195,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   # by "subkey" sequence consisting of a literal dot (`.`) followed by a non-whitespace character, then one or more word
   # characters, and then one or more characters that do not convey semantic meaning within CEF (e.g., literal-pipe (`|`),
   # whitespace (`\s`), literal-dot (`.`), literal-equals (`=`), or literal-backslash ('\')).
-  EXTENSION_KEY_PATTERN = /(?:\w+(?:\.[^\s]\w+[^\|\s\.\=\\]+)?(?==))/
+  EXTENSION_KEY_PATTERN = /(?:\w+(?:\.\S\w*[^\|\s\.\=\\]+)?(?==))/
 
   # Some CEF extension keys seen in the wild use an undocumented array-like syntax that may not be compatible with
   # the Event API's strict-mode FieldReference parser (e.g., `fieldname[0]`).

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -554,6 +554,16 @@ describe LogStash::Codecs::CEF do
         insist { e.get("sourcePort") } == "1232"
       end
     end
+    
+    let (:dots_in_keys) {'CEF:0|Vendor|Device|Version|13|my message|5|dvchost=loghost cat=traffic deviceSeverity=notice ad.nn=TEST src=192.168.0.1 destinationPort=53'}
+    it "should be OK with dots in keys" do
+      decode_one(subject, dots_in_keys) do |e|
+        insist { e.get("dvchost") } == "loghost"
+        insist { e.get("ad.nn") } == 'TEST'
+        insist { e.get("src") } == '192.168.0.1'
+        insist { e.get("destinationPort") } == '53'
+      end
+    end
 
     let (:allow_spaces_in_values) {'CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|src=10.0.0.192 dst=12.121.122.82  spt=1232 dproc=InternetExplorer x.x.x.x'}
     it "should be OK to have one or more spaces in values" do

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -558,9 +558,9 @@ describe LogStash::Codecs::CEF do
     let (:dots_in_keys) {'CEF:0|Vendor|Device|Version|13|my message|5|dvchost=loghost cat=traffic deviceSeverity=notice ad.nn=TEST src=192.168.0.1 destinationPort=53'}
     it "should be OK with dots in keys" do
       decode_one(subject, dots_in_keys) do |e|
-        insist { e.get("dvchost") } == "loghost"
+        insist { e.get("deviceHostName") } == "loghost"
         insist { e.get("ad.nn") } == 'TEST'
-        insist { e.get("src") } == '192.168.0.1'
+        insist { e.get("sourceAddress") } == '192.168.0.1'
         insist { e.get("destinationPort") } == '53'
       end
     end


### PR DESCRIPTION
attempt to fix #50

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
