### PR TITLE
Refactor: log error type + less (string) garbage

### DIFF
--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -288,8 +288,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     end
 
     # Get rid of the CEF bit in the version
-    cef_version = event.get('cefVersion')
-    event.set('cefVersion', cef_version[CEF_PREFIX.length..-1]) if cef_version.start_with?(CEF_PREFIX)
+    event.set('cefVersion', delete_cef_prefix(event.get('cefVersion')))
 
     # Use a scanning parser to capture the Extension Key/Value Pairs
     if message && message.include?('=')
@@ -430,5 +429,15 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     (f % 1 == 0) && f.between?(0,10)
   rescue TypeError, ArgumentError
     false
+  end
+
+  if Gem::Requirement.new(">= 2.5.0").satisfied_by? Gem::Version.new(RUBY_VERSION)
+    def delete_cef_prefix(cef_version)
+      cef_version.delete_prefix(CEF_PREFIX)
+    end
+  else
+    def delete_cef_prefix(cef_version)
+      cef_version.start_with?(CEF_PREFIX) ? cef_version[CEF_PREFIX.length..-1] : cef_version
+    end
   end
 end

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -385,7 +385,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     value.each_char{|c|
       case c
       when "\\", "="
-        output << "\\" << c
+        output << "\\#{c}"
       when "\n", "\r"
         output << "\\n"
       else

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -311,7 +311,8 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
 
     yield event
   rescue => e
-    @logger.error("Failed to decode CEF payload. Generating failure event with payload in message field.", :error => e.message, :backtrace => e.backtrace, :data => data)
+    @logger.error("Failed to decode CEF payload. Generating failure event with payload in message field.",
+                  :exception => e.class, :message => e.message, :backtrace => e.backtrace, :data => data)
     yield LogStash::Event.new("message" => data, "tags" => ["_cefparsefailure"])
   end
 

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -317,19 +317,19 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     # "CEF:0|Elasticsearch|Logstash|1.0|Signature|Name|Sev|"
 
     vendor = sanitize_header_field(event.sprintf(@vendor))
-    vendor = self.class.get_config["vendor"][:default] if vendor == ""
+    vendor = self.class.get_config["vendor"][:default] if vendor.empty?
 
     product = sanitize_header_field(event.sprintf(@product))
-    product = self.class.get_config["product"][:default] if product == ""
+    product = self.class.get_config["product"][:default] if product.empty?
 
     version = sanitize_header_field(event.sprintf(@version))
-    version = self.class.get_config["version"][:default] if version == ""
+    version = self.class.get_config["version"][:default] if version.empty?
 
     signature = sanitize_header_field(event.sprintf(@signature))
-    signature = self.class.get_config["signature"][:default] if signature == ""
+    signature = self.class.get_config["signature"][:default] if signature.empty?
 
     name = sanitize_header_field(event.sprintf(@name))
-    name = self.class.get_config["name"][:default] if name == ""
+    name = self.class.get_config["name"][:default] if name.empty?
 
     severity = sanitize_severity(event, @severity)
 
@@ -345,18 +345,18 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   # Escape pipes and backslashes in the header. Equal signs are ok.
   # Newlines are forbidden.
   def sanitize_header_field(value)
-    output = ""
+    output = String.new
 
     value = value.to_s.gsub(/\r\n/, "\n")
 
     value.each_char{|c|
       case c
       when "\\", "|"
-        output += "\\" + c
+        output << "\\" << c
       when "\n", "\r"
-        output += " "
+        output << " "
       else
-        output += c
+        output << c
       end
     }
 
@@ -374,18 +374,18 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   # CEF spec leaves it up to us to choose \r or \n for newline.
   # We choose \n as the default.
   def sanitize_extension_val(value)
-    output = ""
+    output = String.new
 
     value = value.to_s.gsub(/\r\n/, "\n")
 
     value.each_char{|c|
       case c
       when "\\", "="
-        output += "\\" + c
+        output << "\\" << c
       when "\n", "\r"
-        output += "\\n"
+        output << "\\n"
       else
-        output += c
+        output << c
       end
     }
 

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -339,7 +339,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
 
     # Should also probably set the fields sent
     header = ["CEF:0", vendor, product, version, signature, name, severity].join("|")
-    values = @fields.map {|fieldname| get_value(fieldname, event)}.compact.join(" ")
+    values = @fields.map { |fieldname| get_value(fieldname, event) }.compact.join(" ")
 
     @on_event.call(event, "#{header}|#{values}#{@delimiter}")
   end
@@ -420,7 +420,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   def sanitize_severity(event, severity)
     severity = sanitize_header_field(event.sprintf(severity)).strip
     severity = self.class.get_config["severity"][:default] unless valid_severity?(severity)
-    severity = severity.to_i.to_s
+    severity.to_i.to_s
   end
 
   def valid_severity?(sev)

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -356,7 +356,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     value.each_char{|c|
       case c
       when "\\", "|"
-        output << "\\" << c
+        output << "\\#{c}"
       when "\n", "\r"
         output << " "
       else


### PR DESCRIPTION
Preparing a sample codec for some ECS goodness, noticed some low hanging fruit.
Notably: less intermediate strings and using the preferred exception logging style ...