### PR TITLE
Feat: (optional) event target => namespace support

### DIFF
--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", "< 2"
+  s.add_runtime_dependency "logstash-mixin-event_support", "< 2"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'


### PR DESCRIPTION
also a step towards using an ECS-like event factory.

https://github.com/kares/logstash-mixin-ecs_compatibility_support/compare/pre-1.0.0...events

- believe these would make sense in the ECS mixin gem?
- an `EventFactory` adapter will need to exist somewhere (even after its added to LS itself)
- a wrapper for handling potential event `target => ns` easily is also something needed due ECS
  (not directly ecs-relevant but cna always get extracted later)

resolves https://github.com/logstash-plugins/logstash-codec-cef/issues/35