### PR TITLE
Improve encoding performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 6.1.1
+ - Improved encoding performance, especially when encoding many extension fields [#81](https://github.com/logstash-plugins/logstash-codec-cef/pull/81)
  - Fixed CEF short to long name translation for ahost/agentHostName field, according to documentation [#75](https://github.com/logstash-plugins/logstash-codec-cef/pull/75)
 
 ## 6.0.1

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -378,8 +378,8 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   # Keys must be made up of a single word, with no spaces
   # must be alphanumeric
   def sanitize_extension_key(value)
-    value = value.to_s.gsub(/[^a-zA-Z0-9]/, "")
-    return value
+    value.to_s
+         .gsub(/[^a-zA-Z0-9]/, "")
   end
 
   # Escape equal signs in the extensions. Canonicalize newlines.

--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cef'
-  s.version         = '6.1.0'
+  s.version         = '6.1.1'
   s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the ArcSight Common Event Format (CEF)."


### PR DESCRIPTION
This change-set replaces character-by-character input sanitizers with equivalent gsub expressions, improving performance especially when many fields are referenced.

For example, when used with the TCP Output and simple field values, I was able to achieve the following maximum throughputs on a 16-worker pipeline:

| fields | char-by-char | gsub inline | gsub constantized |
| ----- | ----- | ----- |----- |
| 1 | 45k | 47k | 49k |
| 12 | 18k | 28k |30k |
| 100 | 3.5k | 7.5k | 8.0k |


