### PR TITLE
Log detailed dump of the payload when the handle method fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## 6.1.2
- - Added error log with full payload when something bad happens in decoding a message[]()
+ - Added error log with full payload when something bad happens in decoding a message[#84](https://github.com/logstash-plugins/logstash-codec-cef/pull/84)
 
 ## 6.1.1
  - Improved encoding performance, especially when encoding many extension fields [#81](https://github.com/logstash-plugins/logstash-codec-cef/pull/81)
 
 ## 6.1.0
->>>>>>> Stashed changes
  - Fixed CEF short to long name translation for ahost/agentHostName field, according to documentation [#75](https://github.com/logstash-plugins/logstash-codec-cef/pull/75)
 
 ## 6.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
+## 6.1.2
+ - Added error log with full payload when something bad happens in decoding a message[]()
+
 ## 6.1.1
  - Improved encoding performance, especially when encoding many extension fields [#81](https://github.com/logstash-plugins/logstash-codec-cef/pull/81)
+
+## 6.1.0
+>>>>>>> Stashed changes
  - Fixed CEF short to long name translation for ahost/agentHostName field, according to documentation [#75](https://github.com/logstash-plugins/logstash-codec-cef/pull/75)
 
 ## 6.0.1

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -261,24 +261,15 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   def decode(data, &block)
     if @delimiter
       @buffer.extract(data).each do |line|
-        dumping_handle(line, &block)
+        handle(line, &block)
       end
     else
-      dumping_handle(data, &block)
-    end
-  end
-
-  def dumping_handle(data, &block)
-    begin
-      original_data = data.dup
       handle(data, &block)
-    rescue => e
-      logger.error("Problem processing data : ", :original_data => original_data)
-      raise
     end
   end
 
   def handle(data, &block)
+    original_data = data.dup
     event = LogStash::Event.new
     event.set(raw_data_field, data) unless raw_data_field.nil?
 
@@ -343,7 +334,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     yield event
   rescue => e
     @logger.error("Failed to decode CEF payload. Generating failure event with payload in message field.",
-                  :exception => e.class, :message => e.message, :backtrace => e.backtrace, :data => data)
+                  :exception => e.class, :message => e.message, :backtrace => e.backtrace, :original_data => original_data)
     yield LogStash::Event.new("message" => data, "tags" => ["_cefparsefailure"])
   end
 

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -273,7 +273,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
       original_data = data.dup
       handle(data, &block)
     rescue => e
-      logger.error("Problem processing data: ", :original_data => original_data)
+      logger.error("Problem processing data : ", :original_data => original_data)
       raise
     end
   end

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -261,10 +261,20 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   def decode(data, &block)
     if @delimiter
       @buffer.extract(data).each do |line|
-        handle(line, &block)
+        dumping_handle(line, &block)
       end
     else
+      dumping_handle(data, &block)
+    end
+  end
+
+  def dumping_handle(data, &block)
+    begin
+      original_data = data.dup
       handle(data, &block)
+    rescue => e
+      logger.error("Problem processing data: ", :original_data => original_data)
+      raise
     end
   end
 

--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cef'
-  s.version         = '6.1.1'
+  s.version         = '6.1.2'
   s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the ArcSight Common Event Format (CEF)."


### PR DESCRIPTION
When CEF codec fails, the exception raised contains only the data to process and not the full payload, so reproducing or investigate on the error becomes more difficult.
This PR decorate the `handle` method with `rescue, log, raise` pattern