### PR TITLE
Removed git .ci submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".ci"]
-	path = .ci
-	url = https://github.com/logstash-plugins/.ci.git


### PR DESCRIPTION
This PR removes `.ci` submodule.
Usage of shared CI stuff from https://github.com/logstash-plugins/.ci/ is done by Travis so no more needs for .ci git submodule.
