### PR TITLE
Adjust wording for delimiter setting documentation

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -441,7 +441,7 @@ not include timezone information, this `default_timezone` is used instead.
 If your input puts a delimiter between each CEF event, you'll want to set
 this to be that delimiter.
 
-For example, with the TCP input, you probably want to put this:
+Note: Byte stream inputs such as TCP require delimiter to be specified. Otherwise input can be truncated or incorrectly split.
 
     input {
       tcp {

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -441,7 +441,7 @@ not include timezone information, this `default_timezone` is used instead.
 If your input puts a delimiter between each CEF event, you'll want to set
 this to be that delimiter.
 
-Note: Byte stream inputs such as TCP require delimiter to be specified. Otherwise input can be truncated or incorrectly split.
+NOTE: Byte stream inputs such as TCP require delimiter to be specified. Otherwise input can be truncated or incorrectly split.
 
     input {
       tcp {


### PR DESCRIPTION
Description for delimiter setting should be more precise when it comes to byte stream inputs such as TCP.
This additional hint may help properly configure Logstash until https://github.com/logstash-plugins/logstash-codec-cef/issues/90 is implemented.

