### PR TITLE
decode: several fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.2.6
+ - Fix: when decoding, escaped newlines and carriage returns in extension values are now correctly decoded into literal newlines and carriage returns respectively [#98](https://github.com/logstash-plugins/logstash-codec-cef/pull/98)
+
 ## 6.2.5
   - [DOC] Update link to CEF implementation guide [#97](https://github.com/logstash-plugins/logstash-codec-cef/pull/97)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.2.6
  - Fix: when decoding, escaped newlines and carriage returns in extension values are now correctly decoded into literal newlines and carriage returns respectively [#98](https://github.com/logstash-plugins/logstash-codec-cef/pull/98)
  - Fix: when decoding, non-CEF payloads are identified and intercepted to prevent data-loss and corruption. They now cause a descriptive log message to be emitted, and are emitted as their own `_cefparsefailure`-tagged event containing the original bytes in its `message` field [#99](https://github.com/logstash-plugins/logstash-codec-cef/issues/99)
+ - Fix: when decoding while configured with a `delimiter`, flushing this codec now correctly consumes the remainder of its internal buffer. This resolves an issue where bytes that are written without a trailing delimiter could be lost [#100](https://github.com/logstash-plugins/logstash-codec-cef/issues/100) 
 
 ## 6.2.5
   - [DOC] Update link to CEF implementation guide [#97](https://github.com/logstash-plugins/logstash-codec-cef/pull/97)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 6.2.6
  - Fix: when decoding, escaped newlines and carriage returns in extension values are now correctly decoded into literal newlines and carriage returns respectively [#98](https://github.com/logstash-plugins/logstash-codec-cef/pull/98)
+ - Fix: when decoding, non-CEF payloads are identified and intercepted to prevent data-loss and corruption. They now cause a descriptive log message to be emitted, and are emitted as their own `_cefparsefailure`-tagged event containing the original bytes in its `message` field [#99](https://github.com/logstash-plugins/logstash-codec-cef/issues/99)
 
 ## 6.2.5
   - [DOC] Update link to CEF implementation guide [#97](https://github.com/logstash-plugins/logstash-codec-cef/pull/97)

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -210,11 +210,21 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   public
   def decode(data, &block)
     if @delimiter
+      @logger.trace("Buffering #{data.bytesize}B of data") if @logger.trace?
       @buffer.extract(data).each do |line|
+        @logger.trace("Decoding #{line.bytesize + @delimiter.bytesize}B of buffered data") if @logger.trace?
         handle(line, &block)
       end
     else
+      @logger.trace("Decoding #{data.bytesize}B of unbuffered data") if @logger.trace?
       handle(data, &block)
+    end
+  end
+
+  def flush(&block)
+    if @delimiter && (remainder = @buffer.flush)
+      @logger.trace("Flushing #{remainder.bytesize}B of buffered data") if @logger.trace?
+      handle(remainder, &block) unless remainder.empty?
     end
   end
 

--- a/lib/logstash/codecs/cef/timestamp_normalizer.rb
+++ b/lib/logstash/codecs/cef/timestamp_normalizer.rb
@@ -84,9 +84,6 @@ class LogStash::Codecs::CEF::TimestampNormalizer
 
     # Ruby's `Time::at(sec, microseconds_with_frac)`
     Time.at(parsed_time.get_epoch_second, Rational(parsed_time.get_nano, 1000))
-  rescue => e
-    $stderr.puts "parse_cef_format_sgring(#{value.inspect}, #{context_timezone.inspect}) #!=> #{e.message}"
-    raise
   end
 
   def resolve_assuming_year(parsed_temporal_accessor)

--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cef'
-  s.version         = '6.2.5'
+  s.version         = '6.2.6'
   s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the ArcSight Common Event Format (CEF)."

--- a/spec/codecs/cef/timestamp_normalizer_spec.rb
+++ b/spec/codecs/cef/timestamp_normalizer_spec.rb
@@ -159,7 +159,6 @@ describe LogStash::Codecs::CEF::TimestampNormalizer do
       context 'and handling a yearless date string from mid january' do
         let(:time_to_parse) { Time.parse("2021-01-17T00:00:08.123456789Z") }
         it 'assumes that the date being parsed is in the distant past' do
-          $stderr.puts(parsable_string)
           expect(parsed_result.month).to eq(1)
           expect(parsed_result.year).to eq(time_of_parse.year)
         end

--- a/spec/codecs/cef_spec.rb
+++ b/spec/codecs/cef_spec.rb
@@ -548,6 +548,23 @@ describe LogStash::Codecs::CEF do
         end
       end
 
+      let(:literal_newline)         { "\n" }
+      let(:literal_carriage_return) { "\r" }
+      let(:literal_equals)          { "=" }
+      let(:literal_backslash)       { "\\" }
+      let(:escaped_newline)         { literal_backslash + 'n' }
+      let(:escaped_carriage_return) { literal_backslash + 'r' }
+      let(:escaped_equals)          { literal_backslash + literal_equals }
+      let(:escaped_backslash)       { literal_backslash + literal_backslash }
+      let(:escaped_sequences_in_extension_value) { "CEF:0|security|threatmanager|1.0|100|trojan successfully stopped|10|foo=bar msg=this message has escaped equals #{escaped_equals} and escaped newlines #{escaped_newline} escaped carriage returns #{escaped_carriage_return} and escaped backslashes #{escaped_backslash} in it bar=baz" }
+      it "decodes embedded newlines, carriage regurns, backslashes, and equals signs" do
+        decode_one(subject, escaped_sequences_in_extension_value) do |e|
+          insist { e.get("foo") } == 'bar'
+          insist { e.get("message") } == "this message has escaped equals #{literal_equals} and escaped newlines #{literal_newline} escaped carriage returns #{literal_carriage_return} and escaped backslashes #{literal_backslash} in it"
+          insist { e.get("bar") } == 'baz'
+        end
+      end
+
       context "zoneless deviceReceiptTime(rt) when deviceTimeZone(dtz) is provided" do
         let(:cef_formatted_timestamp) { 'Jul 19 2017 10:50:21.127' }
         let(:zone_name) { 'Europe/Moscow' }


### PR DESCRIPTION
This changeset includes three fixes related to decoding:

1. correctly handle escaped newlines and carriage returns in extension values
2. avoid data-loss and corruption by identifying and intercepting invalid payloads
3. avoid data-loss by ensuring a buffered codec flushes its internal buffer

## CR/LF in Extension Values

Per CEF spec v25 (2017-09-28):

> *Multi-line* fields can be sent by `CEF` by encoding the newline character
> as `\n` or `\r`. Note that multiple lines are only allowed in the value part
> of the extensions

While this plugin has long _encoded_ multiline extension values and other
escape sequences, our _decode_ has only supported escaped backslashes or
escaped equals signs, and with this change becomes compliant with this portion
of the spec. Note that due to the preexisting newline-centric normalization,
round-trip encode/decode cycle is only _semantically_ guaranteed.

## Intercepting Invalid Payloads

> When encountering malformed-CEF or non-CEF payloads, this plugin now emits
> helpful descriptive log messages, and prevents data-loss and corruption by
> emitting an event tagged with `_cefparsefailure` containing the bytes it
> received.
> 
> This set of changes catches 3 distinct cases of malformed payloads.
> 
>   - missing one or more of the 7 required CEF header fields; a payload that
>     does not have all 7 unescaped-pipe-terminated header fields cannot be
>     reliably interpreted as CEF (prevents corruption).
>   - containing something OTHER than a sequence of key=value pairs in the
>     extensions space (prevent data-loss; previously when extensions were
>     invalid they were silently omitted)
>   - containing unescaped newlines (prevents corruption; previously data after
>     the first newline was injected into the currently-parsed extension field)
> 
> In catching these classes of malformed inputs, this changeset also
> resolves https://github.com/logstash-plugins/logstash-codec-cef/issues/99 in which our failure
> to detect a malformed input proactively caused an unhelpful `NoMethodError`
> message to be logged before a `_cefparsefailure`-tagged event was emitted.


## Buffer Flushing

When configured with `delimiter`, this plugin creates an internal buffer.
When that buffer is present, this codec needs to implement `CEF#flush` so that the buffered bytes can be consumed when this codec is being flushed/closed.