### PR TITLE
fix: handle present-and-empty timestamp extension fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.2.7
+ - Fix: when decoding in an ecs_compatibility mode, timestamp-normalized fields now handle provided-but-empty values [#102](https://github.com/logstash-plugins/logstash-codec-cef/issues/102)
+
 ## 6.2.6
  - Fix: when decoding, escaped newlines and carriage returns in extension values are now correctly decoded into literal newlines and carriage returns respectively [#98](https://github.com/logstash-plugins/logstash-codec-cef/pull/98)
  - Fix: when decoding, non-CEF payloads are identified and intercepted to prevent data-loss and corruption. They now cause a descriptive log message to be emitted, and are emitted as their own `_cefparsefailure`-tagged event containing the original bytes in its `message` field [#99](https://github.com/logstash-plugins/logstash-codec-cef/issues/99)

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -201,7 +201,7 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
     end
 
     require_relative 'cef/timestamp_normalizer'
-    @timestamp_normalzer = TimestampNormalizer.new(locale: @locale, timezone: @default_timezone)
+    @timestamp_normalizer = TimestampNormalizer.new(locale: @locale, timezone: @default_timezone)
 
     generate_header_fields!
     generate_mappings!
@@ -604,9 +604,11 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
   end
 
   def normalize_timestamp(value, device_timezone_name)
-    value = @timestamp_normalzer.normalize(value, device_timezone_name).iso8601(9)
+    return nil if value.nil? || value.to_s.strip.empty?
 
-    LogStash::Timestamp.new(value)
+    normalized = @timestamp_normalizer.normalize(value, device_timezone_name).iso8601(9)
+
+    LogStash::Timestamp.new(normalized)
   rescue => e
     @logger.error("Failed to parse CEF timestamp value `#{value}` (#{e.message})")
     raise InvalidTimestamp.new("Not a valid CEF timestamp: `#{value}`")

--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cef'
-  s.version         = '6.2.6'
+  s.version         = '6.2.7'
   s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the ArcSight Common Event Format (CEF)."


### PR DESCRIPTION
When an ECS-mode timestamp-normalized field is processed, empty values map to `nil` instead of producing a parse error.

Fixes: logstash-plugins/logstash-codec-cef#101
