### PR TITLE
Fixes the plugin crash when version field is not available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.2.8
+ - Fixes the plugin crash when version field is not available [#104](https://github.com/logstash-plugins/logstash-codec-cef/pull/104)
+
 ## 6.2.7
  - Fix: when decoding in an ecs_compatibility mode, timestamp-normalized fields now handle provided-but-empty values [#102](https://github.com/logstash-plugins/logstash-codec-cef/issues/102)
 

--- a/lib/logstash/codecs/cef.rb
+++ b/lib/logstash/codecs/cef.rb
@@ -271,7 +271,8 @@ class LogStash::Codecs::CEF < LogStash::Codecs::Base
 
     # Try and parse out the syslog header if there is one
     cef_version_field = @header_fields[0]
-    if (cef_version = event.get(cef_version_field)).include?(' ')
+    cef_version = event.get(cef_version_field)
+    if cef_version && cef_version.include?(' ')
       split_cef_version = cef_version.rpartition(' ')
       event.set(@syslog_header, split_cef_version[0])
       event.set(cef_version_field, split_cef_version[2])

--- a/logstash-codec-cef.gemspec
+++ b/logstash-codec-cef.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cef'
-  s.version         = '6.2.7'
+  s.version         = '6.2.8'
   s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads the ArcSight Common Event Format (CEF)."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.homepage        = "https://www.elastic.co/logstash"
   s.require_paths = ["lib"]
 
   # Files


### PR DESCRIPTION
### Description
We got following error message indicates that version field may be null so that leads plugin crash.

```
{"level":"ERROR","loggerName":"logstash.codecs.cef","timeMillis":1721266426115,"thread":"nioEventLoopGroup-8-1","logEvent":{"message":"Failed to decode CEF payload. Generating failure event with payload in message field.","exception":{"metaClass":{"metaClass":{"exception":"NoMethodError","message":"undefined method `include?' for nil:NilClass","backtrace":["/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-codec-cef-6.2.5-java/lib/logstash/codecs/cef.rb:241:in `handle'","/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-codec-cef-6.2.5-java/lib/logstash/codecs/cef.rb:197:in `block in decode'","org/jruby/RubyArray.java:1821:in `each'","/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-codec-cef-6.2.5-java/lib/logstash/codecs/cef.rb:196:in `decode'","/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-tcp-6.3.0-java/lib/logstash/inputs/tcp.rb:194:in `decode_buffer'","/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-tcp-6.3.0-java/lib/logstash/inputs/tcp/decoder_impl.rb:22:in `decode'"],"original_data":"1245"}}}}}
```